### PR TITLE
Add static methods from angular file uploader to the Banno variant

### DIFF
--- a/banno-file-upload.js
+++ b/banno-file-upload.js
@@ -37,6 +37,12 @@ uploaderModule.factory('BannoUploader', ['$cookies', '$http', 'FileUploader', fu
 	FileUploader.prototype = Object.create(ParentClass.prototype, {});
 	FileUploader.prototype.constructor = FileUploader;
 
+	for(var prop in ParentClass) {
+		if (ParentClass.hasOwnProperty(prop)) {
+			FileUploader[prop] = ParentClass[prop];
+		}
+	}
+
 	return FileUploader;
 }]);
 

--- a/test/test-factory.js
+++ b/test/test-factory.js
@@ -22,6 +22,10 @@ define(['testModule'], function() {
 			BannoUploader = _BannoUploader_;
 		}));
 
+		it('should have the angularFileUpload static properties', function() {
+			expect(BannoUploader.FileItem).toBeDefined();
+		});
+
 		it('should construct a new BannoUploader object', function() {
 			var obj = new BannoUploader(testUrl);
 			expect(obj).toEqual(jasmine.any(Object));


### PR DESCRIPTION
Copy the static properties from the angular file uploader (particularly the `FileItem class`) to the Banno FileUploader class. Once committed and merged, Banno/platform-ux#193 should be reverted.
